### PR TITLE
The rate is set correctly.

### DIFF
--- a/SwiftAudio/Classes/AudioPlayer.swift
+++ b/SwiftAudio/Classes/AudioPlayer.swift
@@ -268,7 +268,10 @@ public class AudioPlayer {
 extension AudioPlayer: AVPlayerWrapperDelegate {
     
     func AVWrapper(didChangeState state: AVPlayerWrapperState) {
-        updatePlaybackValues()
+        switch state {
+        case .playing, .paused: updatePlaybackValues()
+        default: break
+        }
         self.delegate?.audioPlayer(playerDidChangeState: state)
     }
     


### PR DESCRIPTION
The rate was set to 1.0 to early, resulting in unsynced elapsed time in the now playing infocenter.