### PR TITLE
Queue functions

### DIFF
--- a/Example/Tests/QueueManagerTests.swift
+++ b/Example/Tests/QueueManagerTests.swift
@@ -170,6 +170,18 @@ class QueueManagerTests: QuickSpec {
                             expect(manager.current).to(equal(self.dummyItems.first))
                         })
                     })
+                    
+                    context("then removing previous items", {
+                        beforeEach {
+                            manager.removePreviousItems()
+                        }
+                        it("should have no previous items", closure: {
+                            expect(manager.previousItems.count).to(equal(0))
+                        })
+                        it("should have current index zero", closure: {
+                            expect(manager.currentIndex).to(equal(0))
+                        })
+                    })
                 })
                 
                 context("adding more items", {

--- a/Example/Tests/QueuedAudioPlayerTests.swift
+++ b/Example/Tests/QueuedAudioPlayerTests.swift
@@ -98,6 +98,26 @@ class QueuedAudioPlayerTests: QuickSpec {
                             expect(audioPlayer.nextItems.count).to(equal(0))
                         })
                     })
+                    
+                    context("then removing upcoming items", {
+                        beforeEach {
+                            audioPlayer.removeUpcomingItems()
+                        }
+                        
+                        it("should be empty", closure: {
+                            expect(audioPlayer.nextItems.count).to(equal(0))
+                        })
+                    })
+                    
+                    context("then stopping", {
+                        beforeEach {
+                            audioPlayer.stop()
+                        }
+                        
+                        it("should be empty", closure: {
+                            expect(audioPlayer.nextItems.count).to(equal(0))
+                        })
+                    })
                 })
             })
             
@@ -121,6 +141,26 @@ class QueuedAudioPlayerTests: QuickSpec {
                         }
                         it("should contain one item", closure: {
                             expect(audioPlayer.previousItems.count).to(equal(1))
+                        })
+                    })
+                    
+                    context("then removing all previous items", {
+                        beforeEach {
+                            audioPlayer.removePreviousItems()
+                        }
+                        
+                        it("should be empty", closure: {
+                            expect(audioPlayer.previousItems.count).to(equal(0))
+                        })
+                    })
+                    
+                    context("then stopping", {
+                        beforeEach {
+                            audioPlayer.stop()
+                        }
+                        
+                        it("should be empty", closure: {
+                            expect(audioPlayer.previousItems.count).to(equal(0))
                         })
                     })
                     

--- a/README.md
+++ b/README.md
@@ -18,12 +18,20 @@ iOS 10.0+
 
 ## Installation
 
+### CocoaPods
 SwiftAudio is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
 pod 'SwiftAudio', '~> 0.4.0'
 ```
+
+### Carthage
+SwiftAudio supports [Carthage](https://github.com/Carthage/Carthage). Add this to your Cartfile:
+```ruby
+github "jorgenhenrichsen/SwiftAudio" ~> 0.4.0
+```
+Then follow the rest of Carthage instructions on [adding a framework](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
 
 ## Usage
 

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -144,7 +144,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         }
     }
 
-    public func load(from url: URL, playWhenReady: Bool) {
+    func load(from url: URL, playWhenReady: Bool) {
         reset(soft: true)
         _playWhenReady = playWhenReady
         _state = .loading

--- a/SwiftAudio/Classes/AudioPlayer.swift
+++ b/SwiftAudio/Classes/AudioPlayer.swift
@@ -259,7 +259,7 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
     
     // MARK: - Private
     
-    private func reset() {
+    func reset() {
         self._currentItem = nil
     }
     

--- a/SwiftAudio/Classes/QueueManager.swift
+++ b/SwiftAudio/Classes/QueueManager.swift
@@ -203,6 +203,15 @@ class QueueManager<T> {
         
         self._items[_currentIndex] = item
     }
+    
+    /**
+     Remove all previous items in the queue.
+     */
+    public func removePreviousItems() {
+        guard currentIndex > 0 else { return }
+        _items.removeSubrange(0..<_currentIndex)
+        _currentIndex = 0
+    }
 
     /**
      Remove upcoming items.

--- a/SwiftAudio/Classes/QueueManager.swift
+++ b/SwiftAudio/Classes/QueueManager.swift
@@ -206,6 +206,7 @@ class QueueManager<T> {
     
     /**
      Remove all previous items in the queue.
+     If no previous items exist, no action will be taken.
      */
     public func removePreviousItems() {
         guard currentIndex > 0 else { return }
@@ -215,6 +216,7 @@ class QueueManager<T> {
 
     /**
      Remove upcoming items.
+     If no upcoming items exist, no action will be taken.
      */
     public func removeUpcomingItems() {
         let nextIndex = _currentIndex + 1

--- a/SwiftAudio/Classes/QueuedAudioPlayer.swift
+++ b/SwiftAudio/Classes/QueuedAudioPlayer.swift
@@ -30,6 +30,9 @@ public class QueuedAudioPlayer: AudioPlayer {
      */
     public override func stop() {
         super.stop()
+    }
+    
+    override func reset() {
         queueManager.clearQueue()
     }
     
@@ -156,6 +159,13 @@ public class QueuedAudioPlayer: AudioPlayer {
      */
     public func removeUpcomingItems() {
         queueManager.removeUpcomingItems()
+    }
+    
+    /**
+     Remove all previous items, those returned by `previous()`
+     */
+    public func removePreviousItems() {
+        queueManager.removePreviousItems()
     }
     
     // MARK: - AVPlayerWrapperDelegate


### PR DESCRIPTION
- Clear queue at `reset()` in the `QueuedAudioPlayer`, which happens when `stop()` is called.
- Can clear previous items in the queue with `removePreviousItems()`