### PR TITLE
Unregister observer before removing AVPlayerItem.

### DIFF
--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -165,12 +165,13 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     // MARK: - Util
     
     private func reset(soft: Bool) {
+        playerItemObserver.stopObservingCurrentItem()
+        playerTimeObserver.unregisterForBoundaryTimeEvents()
+        playerItemNotificationObserver.stopObservingCurrentItem()
+        
         if !soft {
             avPlayer.replaceCurrentItem(with: nil)
         }
-        
-        playerTimeObserver.unregisterForBoundaryTimeEvents()
-        playerItemNotificationObserver.stopObservingCurrentItem()
     }
     
 }

--- a/SwiftAudio/Classes/Observer/AVPlayerItemObserver.swift
+++ b/SwiftAudio/Classes/Observer/AVPlayerItemObserver.swift
@@ -56,7 +56,7 @@ class AVPlayerItemObserver: NSObject {
         }
     }
     
-    private func stopObservingCurrentItem() {
+    func stopObservingCurrentItem() {
         observingItem?.removeObserver(self, forKeyPath: AVPlayerItemKeyPath.duration, context: &AVPlayerItemObserver.context)
         self.isObserving = false
         self.observingItem = nil


### PR DESCRIPTION
Should fix a problem where the AVPlayerWrapper's item was deinitialized while observers where observing the item.