### PR TITLE
Get duration directly from asset

### DIFF
--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -85,7 +85,10 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     }
 
     var duration: TimeInterval {
-        if let seconds = currentItem?.duration.seconds, !seconds.isNaN {
+        if let seconds = currentItem?.asset.duration.seconds, !seconds.isNaN {
+            return seconds
+        }
+        else if let seconds = currentItem?.duration.seconds, !seconds.isNaN {
             return seconds
         }
         else if let seconds = currentItem?.loadedTimeRanges.first?.timeRangeValue.duration.seconds,


### PR DESCRIPTION
It is more reliable because the current item directly will return NaN depending on what's loaded.