### PR TITLE
Increase timescale in seekto(time:) method.

### DIFF
--- a/Example/Tests/AVPlayerWrapperTests.swift
+++ b/Example/Tests/AVPlayerWrapperTests.swift
@@ -151,18 +151,16 @@ class AVPlayerWrapperTests: QuickSpec {
                 })
                 
                 context("when seeking to a time", {
-                    var passed = false
                     let holder = AVPlayerWrapperDelegateHolder()
                     let seekTime: TimeInterval = 0.5
                     beforeEach {
                         wrapper.delegate = holder
-                        holder.seekCompletion = { passed = true }
                         wrapper.load(from: Source.url, playWhenReady: false)
                         wrapper.seek(to: seekTime)
                     }
                     
                     it("should eventually be equal to the seeked time", closure: {
-                        expect(passed).toEventually(beTrue())
+                        expect(wrapper.currentTime).toEventually(equal(seekTime))
                     })
                 })
             })

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -146,7 +146,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     }
     
     func seek(to seconds: TimeInterval) {
-        avPlayer.seek(to: CMTimeMakeWithSeconds(seconds, preferredTimescale: 1)) { (finished) in
+        avPlayer.seek(to: CMTimeMakeWithSeconds(seconds, preferredTimescale: 1000)) { (finished) in
             self.delegate?.AVWrapper(seekTo: Int(seconds), didFinish: finished)
         }
     }


### PR DESCRIPTION
Stops truncating of the seeked to time.
Also updated seekTo test to actually test the seeked value.