### PR TITLE
Fix crash on modification requires exclusive access

### DIFF
--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
@@ -9,7 +9,7 @@ import Foundation
 import AVFoundation
 
 
-protocol AVPlayerWrapperProtocol {
+protocol AVPlayerWrapperProtocol: class {
     
     var state: AVPlayerWrapperState { get }
     


### PR DESCRIPTION
Fix crash: Simultaneous accesses to 0x608000141e50, but modification requires exclusive access.  (https://github.com/react-native-kit/react-native-track-player/issues/516)

The AVPlayerWrapperProtocol type without class bound will acts with the struct level of restriction, change to a class instead of struct should fix this issue.