### PR TITLE
Add ability to set auth headers

### DIFF
--- a/Example/Tests/AVPlayerWrapperTests.swift
+++ b/Example/Tests/AVPlayerWrapperTests.swift
@@ -99,7 +99,7 @@ class AVPlayerWrapperTests: XCTestCase {
             default: break
             }
         }
-        wrapper.load(from: LongSource.url, playWhenReady: true, initialTime: 4.0)
+        wrapper.load(from: LongSource.url, playWhenReady: true, initialTime: 4.0, headers: [:])
         wait(for: [expectation], timeout: 20.0)
     }
     
@@ -146,7 +146,8 @@ class AVPlayerWrapperTests: XCTestCase {
         holder.didSeekTo = { seconds in
             expectation.fulfill()
         }
-        wrapper.load(from: LongSource.url, playWhenReady: false, initialTime: 4.0)
+        
+        wrapper.load(from: LongSource.url, playWhenReady: false, initialTime: 4.0, headers: [:])
         wait(for: [expectation], timeout: 20.0)
     }
     

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -168,7 +168,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         }
     }
     
-    func load(from url: URL, playWhenReady: Bool) {
+    func load(from url: URL, playWhenReady: Bool, headers: [String: Any]? = nil) {
         reset(soft: true)
         _playWhenReady = playWhenReady
 
@@ -176,8 +176,13 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
             recreateAVPlayer()
         }
         
+        var options: [String: Any] = [:]
+        if let headers = headers {
+            options = ["AVURLAssetHTTPHeaderFieldsKey": headers]
+        }
+        
         // Set item
-        self._pendingAsset = AVURLAsset(url: url)
+        self._pendingAsset = AVURLAsset(url: url, options: options)
         if let pendingAsset = _pendingAsset {
             pendingAsset.loadValuesAsynchronously(forKeys: [Constants.assetPlayableKey], completionHandler: {
                 var error: NSError? = nil
@@ -220,10 +225,10 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         }
     }
     
-    func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?) {
+    func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?, headers: [String: Any]?) {
         _initialTime = initialTime
         self.pause()
-        self.load(from: url, playWhenReady: playWhenReady)
+        self.load(from: url, playWhenReady: playWhenReady, headers: headers)
     }
     
     // MARK: - Util

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
@@ -49,8 +49,7 @@ protocol AVPlayerWrapperProtocol: class {
     
     func seek(to seconds: TimeInterval)
     
-    func load(from url: URL, playWhenReady: Bool)
-    
-    func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?)
+    func load(from url: URL, playWhenReady: Bool, headers: [String: Any]?)
+    func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?, headers: [String: Any]?)
     
 }

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
@@ -50,6 +50,7 @@ protocol AVPlayerWrapperProtocol: class {
     func seek(to seconds: TimeInterval)
     
     func load(from url: URL, playWhenReady: Bool, headers: [String: Any]?)
+    
     func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?, headers: [String: Any]?)
     
 }

--- a/SwiftAudio/Classes/AudioItem.swift
+++ b/SwiftAudio/Classes/AudioItem.swift
@@ -36,6 +36,11 @@ public protocol InitialTiming {
     func getInitialTime() -> TimeInterval
 }
 
+/// Make your `AudioItem`-subclass conform to this protocol to control enable the ability to set authorization headers.
+public protocol Authorizing {
+    func getHeaders() -> [String: Any]
+}
+
 public class DefaultAudioItem: AudioItem {
     
     public var audioUrl: String
@@ -122,6 +127,27 @@ public class DefaultAudioItemInitialTime: DefaultAudioItem, InitialTiming {
     
     public func getInitialTime() -> TimeInterval {
         return initialTime
+    }
+    
+}
+
+/// An AudioItem that also conforms to the `Authorizing`-protocol
+public class DefaultAudioItemAuthorizing: DefaultAudioItem, Authorizing {
+    
+    public var headers: [String: Any]
+    
+    public override init(audioUrl: String, artist: String?, title: String?, albumTitle: String?, sourceType: SourceType, artwork: UIImage?) {
+        self.headers = [:]
+        super.init(audioUrl: audioUrl, artist: artist, title: title, albumTitle: albumTitle, sourceType: sourceType, artwork: artwork)
+    }
+    
+    public init(audioUrl: String, artist: String?, title: String?, albumTitle: String?, sourceType: SourceType, artwork: UIImage?, headers: [String: Any]) {
+        self.headers = headers
+        super.init(audioUrl: audioUrl, artist: artist, title: title, albumTitle: albumTitle, sourceType: sourceType, artwork: artwork)
+    }
+    
+    public func getHeaders() -> [String: Any] {
+        return headers
     }
     
 }

--- a/SwiftAudio/Classes/AudioPlayer.swift
+++ b/SwiftAudio/Classes/AudioPlayer.swift
@@ -161,7 +161,8 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
         
         wrapper.load(from: url,
                      playWhenReady: playWhenReady,
-                     initialTime: (item as? InitialTiming)?.getInitialTime())
+                     initialTime: (item as? InitialTiming)?.getInitialTime(),
+                     headers: (item as? Authorizing)?.getHeaders())
         
         self._currentItem = item
         


### PR DESCRIPTION
Sometimes authentication headers are required to access data, this allows you to set authentication headers for tracks. It follows the existing strategy, using an `Authorization` protocol.

I'm not sure about tests however.. I've tested with a custom setup, but not sure how to best to set it up for tests as we'd have to rely on something being available online?

Welcome feedback @jorgenhenrichsen :)