### PR TITLE
Set Item Commands only when Protocol

### DIFF
--- a/SwiftAudio/Classes/AudioPlayer.swift
+++ b/SwiftAudio/Classes/AudioPlayer.swift
@@ -168,7 +168,10 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
         if (automaticallyUpdateNowPlayingInfo) {
             self.loadNowPlayingMetaValues()
         }
-        enableRemoteCommands(forItem: item)
+        
+        if (item is RemoteCommandable) {
+            enableRemoteCommands(forItem: item)
+        }
     }
     
     /**


### PR DESCRIPTION
At the moment the player always tries to set remote commands based on the item.. however the player also has methods in which you can update it yourself. which can create conflict if you're trying to manage the remote actions manually.

Therefore, I've set it to use the item commands only if you've implemented the protocol in your item. Which acts an explicit intent to control commands via the item and also doesn't interfere with you if you're trying to set them manually.