### PR TITLE
Async fixes

### DIFF
--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -168,6 +168,8 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         }
     }
     
+    
+    
     func load(from url: URL, playWhenReady: Bool) {
         reset(soft: true)
         _playWhenReady = playWhenReady
@@ -177,9 +179,16 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         }
         
         // Set item
+        self._pendingAsset?.cancelLoading() // Cancel loading if an item is already being loaded when loading a new item.
         self._pendingAsset = AVURLAsset(url: url)
+        
         if let pendingAsset = _pendingAsset {
-            pendingAsset.loadValuesAsynchronously(forKeys: [Constants.assetPlayableKey], completionHandler: {
+            pendingAsset.loadValuesAsynchronously(forKeys: [Constants.assetPlayableKey], completionHandler: { [weak self] in
+                
+                guard let self = self else {
+                    return
+                }
+                
                 var error: NSError? = nil
                 let status = pendingAsset.statusOfValue(forKey: Constants.assetPlayableKey, error: &error)
                 

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -208,7 +208,6 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
                         break
                         
                     case .failed:
-                        // print("load asset failed")
                         if isPendingAsset {
                             self.delegate?.AVWrapper(failedWithError: error)
                             self._pendingAsset = nil
@@ -216,7 +215,6 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
                         break
                         
                     case .cancelled:
-                        // print("load asset cancelled")
                         break
                         
                     default:

--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -178,8 +178,6 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
             recreateAVPlayer()
         }
         
-        // Set item
-        self._pendingAsset?.cancelLoading() // Cancel loading if an item is already being loaded when loading a new item.
         self._pendingAsset = AVURLAsset(url: url)
         
         if let pendingAsset = _pendingAsset {
@@ -242,10 +240,8 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         playerTimeObserver.unregisterForBoundaryTimeEvents()
         playerItemNotificationObserver.stopObservingCurrentItem()
         
-        if self._pendingAsset != nil {
-            self._pendingAsset?.cancelLoading()
-            self._pendingAsset = nil
-        }
+        self._pendingAsset?.cancelLoading()
+        self._pendingAsset = nil
         
         if !soft {
             avPlayer.replaceCurrentItem(with: nil)

--- a/SwiftAudio/Classes/Observer/AVPlayerItemNotificationObserver.swift
+++ b/SwiftAudio/Classes/Observer/AVPlayerItemNotificationObserver.swift
@@ -22,8 +22,14 @@ class AVPlayerItemNotificationObserver {
     
     private let notificationCenter: NotificationCenter = NotificationCenter.default
     
-    weak var observingItem: AVPlayerItem?
+    private(set) weak var observingItem: AVPlayerItem?
     weak var delegate: AVPlayerItemNotificationObserverDelegate?
+    
+    private(set) var isObserving: Bool = false
+    
+    deinit {
+        stopObservingCurrentItem()
+    }
     
     /**
      Will start observing notifications from an item.
@@ -34,6 +40,7 @@ class AVPlayerItemNotificationObserver {
     func startObserving(item: AVPlayerItem) {
         stopObservingCurrentItem()
         observingItem = item
+        isObserving = true
         notificationCenter.addObserver(self, selector: #selector(itemDidPlayToEndTime), name: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: item)
     }
     
@@ -41,10 +48,12 @@ class AVPlayerItemNotificationObserver {
      Stop receiving notifications for the current item.
      */
     func stopObservingCurrentItem() {
-        if let observingItem = observingItem {
-            notificationCenter.removeObserver(self, name: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: observingItem)
+        guard let observingItem = observingItem, isObserving else {
+            return
         }
-        observingItem = nil
+        self.notificationCenter.removeObserver(self, name: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: observingItem)
+        self.observingItem = nil
+        self.isObserving = false
     }
     
     @objc private func itemDidPlayToEndTime() {

--- a/SwiftAudio/Classes/Observer/AVPlayerItemObserver.swift
+++ b/SwiftAudio/Classes/Observer/AVPlayerItemObserver.swift
@@ -30,37 +30,34 @@ class AVPlayerItemObserver: NSObject {
         static let loadedTimeRanges = #keyPath(AVPlayerItem.loadedTimeRanges)
     }
     
-    var isObserving: Bool = false
+    private(set) var isObserving: Bool = false
     
-    weak var observingItem: AVPlayerItem?
+    private(set) weak var observingItem: AVPlayerItem?
     weak var delegate: AVPlayerItemObserverDelegate?
     
     deinit {
-        if self.isObserving {
-            stopObservingCurrentItem()
-        }
+        stopObservingCurrentItem()
     }
     
     /**
-     Start observing an item. Will remove self as observer from old item.
+     Start observing an item. Will remove self as observer from old item, if any.
      
      - parameter item: The player item to observe.
      */
     func startObserving(item: AVPlayerItem) {
-        main.async {
-            if self.isObserving {
-                self.stopObservingCurrentItem()
-            }
-            self.isObserving = true
-            self.observingItem = item
-            item.addObserver(self, forKeyPath: AVPlayerItemKeyPath.duration, options: [.new], context: &AVPlayerItemObserver.context)
-            item.addObserver(self, forKeyPath: AVPlayerItemKeyPath.loadedTimeRanges, options: [.new], context: &AVPlayerItemObserver.context)
-        }
+        self.stopObservingCurrentItem()
+        self.isObserving = true
+        self.observingItem = item
+        item.addObserver(self, forKeyPath: AVPlayerItemKeyPath.duration, options: [.new], context: &AVPlayerItemObserver.context)
+        item.addObserver(self, forKeyPath: AVPlayerItemKeyPath.loadedTimeRanges, options: [.new], context: &AVPlayerItemObserver.context)
     }
     
     func stopObservingCurrentItem() {
-        observingItem?.removeObserver(self, forKeyPath: AVPlayerItemKeyPath.duration, context: &AVPlayerItemObserver.context)
-        observingItem?.removeObserver(self, forKeyPath: AVPlayerItemKeyPath.loadedTimeRanges, context: &AVPlayerItemObserver.context)
+        guard let observingItem = observingItem, isObserving else {
+            return
+        }
+        observingItem.removeObserver(self, forKeyPath: AVPlayerItemKeyPath.duration, context: &AVPlayerItemObserver.context)
+        observingItem.removeObserver(self, forKeyPath: AVPlayerItemKeyPath.loadedTimeRanges, context: &AVPlayerItemObserver.context)
         self.isObserving = false
         self.observingItem = nil
     }

--- a/SwiftAudio/Classes/Observer/AVPlayerObserver.swift
+++ b/SwiftAudio/Classes/Observer/AVPlayerObserver.swift
@@ -36,10 +36,9 @@ class AVPlayerObserver: NSObject {
         static let timeControlStatus = #keyPath(AVPlayer.timeControlStatus)
     }
     
-
     private let statusChangeOptions: NSKeyValueObservingOptions = [.new, .initial]
     private let timeControlStatusChangeOptions: NSKeyValueObservingOptions = [.new]
-    var isObserving: Bool = false
+    private(set) var isObserving: Bool = false
     
     weak var delegate: AVPlayerObserverDelegate?
     weak var player: AVPlayer? {
@@ -66,13 +65,12 @@ class AVPlayerObserver: NSObject {
     }
     
     func stopObserving() {
-        guard let player = player, self.isObserving else {
+        guard let player = player, isObserving else {
             return
         }
         player.removeObserver(self, forKeyPath: AVPlayerKeyPath.status, context: &AVPlayerObserver.context)
         player.removeObserver(self, forKeyPath: AVPlayerKeyPath.timeControlStatus, context: &AVPlayerObserver.context)
         self.isObserving = false
-        
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
@@ -107,7 +105,6 @@ class AVPlayerObserver: NSObject {
     }
     
     private func handleTimeControlStatusChange(_ change: [NSKeyValueChangeKey: Any]?) {
-        
         let status: AVPlayer.TimeControlStatus
         if let statusNumber = change?[.newKey] as? NSNumber {
             status = AVPlayer.TimeControlStatus(rawValue: statusNumber.intValue)!

--- a/SwiftAudio/Classes/Observer/AVPlayerTimeObserver.swift
+++ b/SwiftAudio/Classes/Observer/AVPlayerTimeObserver.swift
@@ -10,10 +10,8 @@ import Foundation
 import AVFoundation
 
 protocol AVPlayerTimeObserverDelegate: class {
-    
     func audioDidStart()
     func timeEvent(time: CMTime)
-    
 }
 
 /**
@@ -48,6 +46,11 @@ class AVPlayerTimeObserver {
     
     init(periodicObserverTimeInterval: CMTime) {
         self.periodicObserverTimeInterval = periodicObserverTimeInterval
+    }
+    
+    deinit {
+        unregisterForPeriodicEvents()
+        unregisterForBoundaryTimeEvents()
     }
     
     /**


### PR DESCRIPTION
Makes async parts a little safer, proper `deinit` on observers and weak capture of `self` in the load method of the `AVPlayerWrapper`.
Was sometimes receiving INVOPs in the tests because of deallocated objects, but it seems to be more solid now.