### PR TITLE
Seek to initial time

### DIFF
--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -283,10 +283,8 @@ extension AVPlayerWrapper: AVPlayerObserverDelegate {
     
     func player(statusDidChange status: AVPlayer.Status) {
         switch status {
-            
         case .readyToPlay:
-            
-            if _playWhenReady {
+            if _playWhenReady && (_initialTime ?? 0) == 0 {
                 self.play()
             }
             else {


### PR DESCRIPTION
Use initial time operation, even for play when ready. This seemed to be the preferred logic, since "seek(...)" has `playWhenReady` logic in it as well. See https://github.com/jorgenhenrichsen/SwiftAudio/blob/master/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift#L163.