### PR TITLE
Update AudioItem.Swift

### DIFF
--- a/SwiftAudio/Classes/AudioItem.swift
+++ b/SwiftAudio/Classes/AudioItem.swift
@@ -65,7 +65,7 @@ public class DefaultAudioItem: AudioItem {
     }
     
     public func getSourceUrl() -> String {
-        return audioUrl
+        return encodeURL(audioUrl)
     }
     
     public func getArtist() -> String? {
@@ -87,7 +87,18 @@ public class DefaultAudioItem: AudioItem {
     public func getArtwork(_ handler: @escaping (UIImage?) -> Void) {
         handler(artwork)
     }
-    
+    private func encodeURL(_ source:String) -> String {
+        let encodedURL = audioUrl.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        guard let encoded = encodedURL else {
+            fatalError("SourceURL error.")
+        }
+        
+        if !encoded.hasPrefix("http://") && !encoded.hasPrefix("https://") {
+           fatalError("Source is not secure. add http/https to your URL")
+            
+        }
+        return encoded
+    }
 }
 
 /// An AudioItem that also conforms to the `TimePitching`-protocol


### PR DESCRIPTION
At this moment SwiftAudio does not properly encode URLs, hence if you have spaces in your source URL, it will throw an error, same for insecure URLs like those that don't start with a http/https.

This pull request adds:

- Encode URLs properly before loading an item.
- URLs must start with http/https, (for http, please go to info.plist, and add NSAppTransportSecurity and click on the plus icon and type NSAllowsArbitraryLoads then set it to YES)