### PR TITLE
always emit ready event

### DIFF
--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -284,14 +284,12 @@ extension AVPlayerWrapper: AVPlayerObserverDelegate {
     func player(statusDidChange status: AVPlayer.Status) {
         switch status {
         case .readyToPlay:
+            self._state = .ready
             if _playWhenReady && (_initialTime ?? 0) == 0 {
                 self.play()
             }
-            else {
-                self._state = .ready
-                if let initialTime = _initialTime {
-                    self.seek(to: initialTime)
-                }
+            else if let initialTime = _initialTime {
+                self.seek(to: initialTime)
             }
             break
             


### PR DESCRIPTION
If you pass `playWhenReady: true`, state goes directly from `loading` to `playing`, skipping ready state.

Ref: https://github.com/jorgenhenrichsen/SwiftAudio/issues/86