### PR TITLE
fix problem with flickering elapsed time on a lock screen after pausing

### DIFF
--- a/SwiftAudio/Classes/AudioPlayer.swift
+++ b/SwiftAudio/Classes/AudioPlayer.swift
@@ -259,8 +259,8 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
      - Playback rate
      */
     public func updateNowPlayingPlaybackValues() {
-        updateNowPlayingDuration(duration)
         updateNowPlayingCurrentTime(currentTime)
+        updateNowPlayingDuration(duration)
         updateNowPlayingRate(rate)
     }
     


### PR DESCRIPTION
PR fixes a problem with flickering elapsed time and progress after pausing on a lock screen .

Video with problem:
https://vimeo.com/395816456