### PR TITLE
Set _playWhenReady in play and pause.

### DIFF
--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -133,10 +133,12 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     }
     
     func play() {
+        _playWhenReady = true
         avPlayer.play()
     }
     
     func pause() {
+        _playWhenReady = false
         avPlayer.pause()
     }
     


### PR DESCRIPTION
This will allow calling pause or play while a track is loading and having the expected result when it finishes.

Fixes #114 